### PR TITLE
Fix selenium grid CLI option

### DIFF
--- a/libs/balances_selenium/__init__.py
+++ b/libs/balances_selenium/__init__.py
@@ -1,12 +1,9 @@
-from dataclasses import dataclass
-
 import classyclick
 from balances_cli import BasicCLI
 
 from . import webdriver
 
 
-@dataclass
 class SeleniumCLI(BasicCLI):
     """CLI mixin for scrapers that need a Chromium WebDriver."""
 


### PR DESCRIPTION
## Summary
- remove the stale dataclass decorator from SeleniumCLI
- let classyclick 1.x register inherited Selenium options such as --grid

## Verification
- python3 -m py_compile libs/balances_selenium/__init__.py