### PR TITLE
Add tgquery CLI entrypoint and reply handling

### DIFF
--- a/libs/balances_tgquery/__init__.py
+++ b/libs/balances_tgquery/__init__.py
@@ -20,6 +20,7 @@ class TGQueryMixin:
     tg_bot: str = classyclick.Option(
         nargs=2, metavar='TOKEN CHAT_ID', help='For interactive bits, use Telegram instead of stdin'
     )
+    ack_reply: bool = True
     _tg_offset: int = 0
 
     def tg_send_message(self, text, chat_id: str = None):
@@ -116,5 +117,6 @@ class TGQueryMixin:
         sent = self.tg_send_message(text, chat_id=chat_id)
         for u in self.tg_poll_updates(retries=retries, timeout=timeout):
             if u['message'].get('reply_to_message', {}).get('message_id') == sent['result']['message_id']:
-                self.tg_set_message_reaction(u['message']['message_id'], chat_id=u['message']['chat']['id'])
+                if self.ack_reply:
+                    self.tg_set_message_reaction(u['message']['message_id'], chat_id=u['message']['chat']['id'])
                 return u['message']['text']

--- a/libs/balances_tgquery/__init__.py
+++ b/libs/balances_tgquery/__init__.py
@@ -21,6 +21,7 @@ class TGQueryMixin:
         nargs=2, metavar='TOKEN CHAT_ID', help='For interactive bits, use Telegram instead of stdin'
     )
     ack_reply: bool = True
+    tg_topic_id: Optional[int] = None
     _tg_offset: int = 0
 
     def tg_send_message(self, text, chat_id: str = None):
@@ -34,9 +35,13 @@ class TGQueryMixin:
         if chat_id is None:
             chat_id = self.tg_bot[1]
 
+        data = {'chat_id': chat_id, 'text': text, 'parse_mode': 'Markdown'}
+        if self.tg_topic_id is not None:
+            data['message_thread_id'] = self.tg_topic_id
+
         response = requests.post(
             f'{TELEGRAM_API_URL}{self.tg_bot[0]}/sendMessage',
-            data={'chat_id': chat_id, 'text': text, 'parse_mode': 'Markdown'},
+            data=data,
         )
         response.raise_for_status()
         response_json = response.json()
@@ -116,6 +121,8 @@ class TGQueryMixin:
         """
         sent = self.tg_send_message(text, chat_id=chat_id)
         for u in self.tg_poll_updates(retries=retries, timeout=timeout):
+            if 'message' not in u:
+                continue
             if u['message'].get('reply_to_message', {}).get('message_id') == sent['result']['message_id']:
                 if self.ack_reply:
                     self.tg_set_message_reaction(u['message']['message_id'], chat_id=u['message']['chat']['id'])

--- a/libs/balances_tgquery/__init__.py
+++ b/libs/balances_tgquery/__init__.py
@@ -87,6 +87,25 @@ class TGQueryMixin:
 
             time.sleep(1)
 
+    def tg_set_message_reaction(self, message_id: int, chat_id: str = None, emoji='👍'):
+        """Add an emoji reaction to a Telegram message."""
+        if chat_id is None:
+            chat_id = self.tg_bot[1]
+
+        response = requests.post(
+            f'{TELEGRAM_API_URL}{self.tg_bot[0]}/setMessageReaction',
+            data={
+                'chat_id': chat_id,
+                'message_id': message_id,
+                'reaction': json.dumps([{'type': 'emoji', 'emoji': emoji}]),
+            },
+        )
+        response.raise_for_status()
+        response_json = response.json()
+        if not response_json['ok']:
+            raise TGError(response_json.get('description', 'Unknown error'))
+        return response_json
+
     def tg_prompt(self, text, chat_id: str = None, retries: int = None, timeout=30) -> Optional[str]:
         """Send a prompt and return the text of the matching Telegram reply.
 
@@ -97,4 +116,5 @@ class TGQueryMixin:
         sent = self.tg_send_message(text, chat_id=chat_id)
         for u in self.tg_poll_updates(retries=retries, timeout=timeout):
             if u['message'].get('reply_to_message', {}).get('message_id') == sent['result']['message_id']:
+                self.tg_set_message_reaction(u['message']['message_id'], chat_id=u['message']['chat']['id'])
                 return u['message']['text']

--- a/libs/balances_tgquery/__init__.py
+++ b/libs/balances_tgquery/__init__.py
@@ -35,13 +35,9 @@ class TGQueryMixin:
         if chat_id is None:
             chat_id = self.tg_bot[1]
 
-        data = {'chat_id': chat_id, 'text': text, 'parse_mode': 'Markdown'}
-        if self.tg_topic_id is not None:
-            data['message_thread_id'] = self.tg_topic_id
-
         response = requests.post(
             f'{TELEGRAM_API_URL}{self.tg_bot[0]}/sendMessage',
-            data=data,
+            data={'chat_id': chat_id, 'text': text, 'parse_mode': 'Markdown', 'message_thread_id': self.tg_topic_id},
         )
         response.raise_for_status()
         response_json = response.json()
@@ -121,9 +117,7 @@ class TGQueryMixin:
         """
         sent = self.tg_send_message(text, chat_id=chat_id)
         for u in self.tg_poll_updates(retries=retries, timeout=timeout):
-            if 'message' not in u:
-                continue
-            if u['message'].get('reply_to_message', {}).get('message_id') == sent['result']['message_id']:
+            if u.get('message', {}).get('reply_to_message', {}).get('message_id') == sent['result']['message_id']:
                 if self.ack_reply:
                     self.tg_set_message_reaction(u['message']['message_id'], chat_id=u['message']['chat']['id'])
                 return u['message']['text']

--- a/libs/balances_tgquery/__main__.py
+++ b/libs/balances_tgquery/__main__.py
@@ -1,0 +1,48 @@
+import argparse
+import sys
+
+from balances_tgquery import TGQueryMixin
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(
+        prog='python -m balances_tgquery',
+        description='Send a Telegram prompt and print the reply.',
+    )
+    parser.add_argument(
+        'chat_id',
+        help='Telegram chat id',
+    )
+    parser.add_argument('token', help='Telegram bot token')
+    parser.add_argument('message', nargs='+', help='Message text to send')
+    parser.add_argument(
+        '--timeout',
+        type=int,
+        default=30,
+        help='Telegram long-poll timeout in seconds',
+    )
+    parser.add_argument(
+        '--retries',
+        type=int,
+        default=None,
+        help='Maximum poll attempts while waiting for the chat and reply',
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    message = ' '.join(args.message)
+
+    tgquery = TGQueryMixin(tg_bot=(args.token, args.chat_id))
+    reply = tgquery.tg_prompt(message, timeout=args.timeout, retries=args.retries)
+    if reply is None:
+        print('No reply received.', file=sys.stderr)
+        return 1
+
+    print(reply)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a `python -m balances_tgquery` entrypoint for manually testing Telegram prompts
- acknowledge accepted Telegram replies with a thumbs-up reaction by default, configurable with `ack_reply`
- support sending prompts to a Telegram forum topic via `tg_topic_id` / `message_thread_id`
- skip non-message updates while waiting for prompt replies

## Testing
- `python3 -m py_compile libs/balances_tgquery/__init__.py libs/balances_tgquery/__main__.py`